### PR TITLE
Add token exchange endpoint for programmatic Barista auth

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -35,6 +35,7 @@ var bar_response = require('bbop-response-barista');
 // We will require our own http client for proxying POST requests with
 // modifications.
 var http = require('http');
+var https = require('https');
 
 ///
 /// Helpers.
@@ -1906,6 +1907,184 @@ var BaristaLauncher = function(){
 	var fin = JSON.stringify(ret_obj);
 	ll('got user info for:' + fin['uri']);
 	_standard_response(res, 200, 'application/json', fin);
+    });
+
+    // REST service that exchanges a GitHub access token for a Barista
+    // session token. The GitHub token is validated against the GitHub
+    // API, the resulting username is looked up in users.yaml, and a
+    // Barista session is created if the user is authorized.
+    //
+    // POST /auth/token/exchange
+    // Body (JSON): { "github_access_token": "gho_..." }
+    // Success: 200 { "token": "...", "nickname": "...", "uri": "..." }
+    // Failure: 401/403 { "error": "..." }
+    //
+    // Rate limiting: simple per-IP tracking, 10 requests per minute.
+    //
+    // Vibe coded by Claude (Opus 4.6) with SJC, 2026-03-21.
+    var _token_exchange_attempts = {};
+    var TOKEN_EXCHANGE_RATE_LIMIT = 10;
+    var TOKEN_EXCHANGE_RATE_WINDOW_MS = 60 * 1000;
+
+    messaging_app.post('/auth/token/exchange', function(req, res) {
+
+	// Rate limiting by IP.
+	var client_ip = req.headers['x-forwarded-for'] ||
+	    req.connection.remoteAddress || 'unknown';
+	var now = Date.now();
+	if( ! _token_exchange_attempts[client_ip] ){
+	    _token_exchange_attempts[client_ip] = [];
+	}
+	// Prune old attempts outside the window.
+	_token_exchange_attempts[client_ip] =
+	    us.filter(_token_exchange_attempts[client_ip], function(t){
+		return (now - t) < TOKEN_EXCHANGE_RATE_WINDOW_MS;
+	    });
+	if( _token_exchange_attempts[client_ip].length >=
+	    TOKEN_EXCHANGE_RATE_LIMIT ){
+	    ll('token exchange rate limited for: ' + client_ip);
+	    var rl_body = JSON.stringify({'error': 'rate limit exceeded'});
+	    _standard_response(res, 429, 'application/json', rl_body);
+	    return;
+	}
+	_token_exchange_attempts[client_ip].push(now);
+
+	// Collect POST body (following existing barista.js idiom).
+	var full_body = '';
+	req.on('data', function(chunk) {
+	    // Guard against oversized payloads.
+	    full_body += chunk.toString();
+	    if( full_body.length > 4096 ){
+		full_body = '';
+		res.writeHead(413, {'Content-Type': 'application/json'});
+		res.end(JSON.stringify({'error': 'payload too large'}));
+		req.destroy();
+	    }
+	});
+	req.on('end', function() {
+
+	    // Parse body.
+	    var parsed = null;
+	    try {
+		parsed = JSON.parse(full_body);
+	    }catch(e){
+		// Bad JSON.
+	    }
+
+	    var github_token = null;
+	    if( parsed && us.isString(parsed['github_access_token']) ){
+		github_token = parsed['github_access_token'];
+	    }
+
+	    if( ! github_token ){
+		ll('token exchange: missing or invalid github_access_token');
+		var bad_body = JSON.stringify(
+		    {'error': 'missing github_access_token'});
+		_standard_response(res, 400, 'application/json', bad_body);
+		return;
+	    }
+
+	    // Validate the GitHub access token by calling the GitHub
+	    // API. This is the only way to confirm the token is real
+	    // and to get the associated username.
+	    var gh_options = {
+		hostname: 'api.github.com',
+		path: '/user',
+		method: 'GET',
+		headers: {
+		    'Authorization': 'Bearer ' + github_token,
+		    'Accept': 'application/json',
+		    'User-Agent': 'Barista-Token-Exchange'
+		}
+	    };
+
+	    var gh_req = https.request(gh_options, function(gh_res) {
+
+		var gh_body = '';
+		gh_res.on('data', function(chunk) {
+		    gh_body += chunk.toString();
+		});
+		gh_res.on('end', function() {
+
+		    // GitHub returns non-200 for bad tokens.
+		    if( gh_res.statusCode !== 200 ){
+			ll('token exchange: GitHub rejected token ' +
+			   '(status ' + gh_res.statusCode + ')');
+			var gh_err = JSON.stringify(
+			    {'error': 'authentication failed'});
+			_standard_response(res, 401,
+					   'application/json', gh_err);
+			return;
+		    }
+
+		    // Parse GitHub response.
+		    var gh_user = null;
+		    try {
+			gh_user = JSON.parse(gh_body);
+		    }catch(e){
+			// Bad response from GitHub.
+		    }
+
+		    var github_username = null;
+		    if( gh_user && us.isString(gh_user['login']) ){
+			github_username = gh_user['login'];
+		    }
+
+		    if( ! github_username ){
+			ll('token exchange: GitHub response missing login');
+			var no_login = JSON.stringify(
+			    {'error': 'authentication failed'});
+			_standard_response(res, 401,
+					   'application/json', no_login);
+			return;
+		    }
+
+		    ll('token exchange: GitHub user validated: ' +
+		       github_username);
+
+		    // Look up and create session using existing
+		    // Sessioner infrastructure -- same path as the
+		    // OAuth callback.
+		    var sess = sessioner.create_session_by_provider(
+			'github', github_username);
+
+		    if( ! sess || ! sess['token'] ){
+			ll('token exchange: user not authorized: ' +
+			   github_username);
+			var no_auth = JSON.stringify(
+			    {'error': 'authorization failed'});
+			_standard_response(res, 403,
+					   'application/json', no_auth);
+			return;
+		    }
+
+		    ll('token exchange: session created for: ' +
+		       github_username + ' (' + sess['uri'] + ')');
+
+		    // Return minimal session info -- token plus
+		    // enough context for the caller to confirm
+		    // identity.
+		    var ret = {
+			'token': sess['token'],
+			'uri': sess['uri'],
+			'nickname': sess['nickname'],
+			'groups': sess['groups']
+		    };
+		    var ok_body = JSON.stringify(ret);
+		    _standard_response(res, 200,
+				       'application/json', ok_body);
+		});
+	    });
+
+	    gh_req.on('error', function(err) {
+		ll('token exchange: GitHub API error: ' + err.message);
+		var api_err = JSON.stringify(
+		    {'error': 'authentication failed'});
+		_standard_response(res, 502, 'application/json', api_err);
+	    });
+
+	    gh_req.end();
+	});
     });
 
     // REST service that returns available information for a user by


### PR DESCRIPTION
## Summary

- Adds `POST /auth/token/exchange` endpoint to barista.js
- Exchanges a GitHub access token for a Barista session token
- Enables external services (e.g., AGR AI Curation) to bridge their GitHub auth with Barista

## Details

Validates the GitHub token against `api.github.com/user`, then uses the existing `sessioner.create_session_by_provider()` — same code path as the browser OAuth callback.

Security: per-IP rate limiting (10/min), 4KB payload limit, POST-only, generic error messages.

Closes #1078

## Test plan

- [ ] Verify existing GitHub OAuth login still works unchanged
- [ ] Test with a valid GitHub access token → returns Barista token
- [ ] Test with an invalid/expired token → returns 401
- [ ] Test with a valid GitHub user NOT in users.yaml → returns 403
- [ ] Test rate limiting (>10 requests/min from same IP) → returns 429
- [ ] Verify returned token works with Minerva API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)