### PR TITLE
Restrict /users to noctua editors and admins (#1093)

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -922,12 +922,16 @@ var Sessioner = function(auth_list, group_list){
     	var noctua_users = [];
     	us.each(auth_list, function(uinf){
 
-	    if( uinf['uri'] &&
-		// Filter out those users without authorization to
-		// edit on this instance.
-		uinf['authorizations'] &&
+	    var ctx_auth = uinf['authorizations'] &&
 		uinf['authorizations']['noctua'] &&
-		uinf['authorizations']['noctua'][barista_context] ){
+		uinf['authorizations']['noctua'][barista_context];
+
+	    // Filter to users with edit or admin authorization on
+	    // this instance; merely having a context entry is not
+	    // enough.
+	    if( uinf['uri'] && ctx_auth &&
+		(ctx_auth['allow-edit'] === true ||
+		 ctx_auth['allow-admin'] === true) ){
 
 		// Get a copy of the info.
 		var copied_info = self.get_info_by_uri(uinf['uri']);


### PR DESCRIPTION
## Summary
- Tightens `Sessioner.known_users()` (the source for the public `GET /users` endpoint) to require `allow-edit === true` or `allow-admin === true` on `authorizations.noctua[context]`, instead of merely checking that the context entry exists.
- Behavior now matches the existing in-code comment ("Filter out those users without authorization to edit on this instance") and aligns with what `authorize_by_uri` / `authorize_by_email` already enforce at lines 530 / 570.
- Closes #1093.

## Notes
- Legacy `authorizations['noctua-go'][user_type]` shape is intentionally **not** honored here. `known_users()` already ignored it pre-change, and we're not aware of any live users.yaml entries that still rely on it. If that turns out to be wrong, the legacy fallback can be added in a follow-up.
- Public/no-token nature of `/users` is unchanged; this strictly narrows the disclosed list.

## Downstream impact
Confirmed consumers of `/users` (all via Angular `noctua-data.service.ts` / `user.service.ts`):
- `noctua-landing-page`
- `noctua-form`
- `noctua-alliance-pathway-preview`
- `noctua-visual-pathway-editor`

Each maps the response into `noctuaUserService.contributors`, which is then used for ORCID → display-name lookup, per-model contributor rendering, and the contributor search facet. Users with a `noctua[context]` entry but no `allow-edit`/`allow-admin` will drop out of those lists; their ORCIDs in historical models will render as bare URLs rather than nicknames. Worth a quick audit of the production users.yaml for such entries before merge.

## Test plan
- [ ] Start barista against a users.yaml that includes (a) an editor, (b) an admin, (c) a user with the context entry but no allow-edit/admin role, and (d) a user with no context entry. Confirm `GET /users` returns only (a) and (b).
- [ ] Load each of the four workbench consumers above against the modified barista and confirm contributor lookups still work for (a)/(b).
- [ ] Verify the `/user_info` admin status page and `/user_info_by_token/:token` are unaffected (this PR only touches `known_users`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)