### PR TITLE
[bot] Validate return URL scheme before use in links (feat-build-node-lts)

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -1491,6 +1491,30 @@ var BaristaLauncher = function () {
     return ret;
   }
 
+  // Sanitize an incoming "return" URL before it reaches an href or a
+  // redirect. The value is attacker-controllable, and HTML-escaping in the
+  // templates does NOT neutralize a dangerous URL *scheme* -- so constrain
+  // it here: site-relative or absolute http(s) only. Anything else
+  // (javascript:, data:, vbscript:, protocol-relative //host) returns null,
+  // and callers then render no return link.
+  function _safe_return_url(url_str){
+    if( ! url_str || typeof url_str !== 'string' ){ return null; }
+    var trimmed = url_str.trim();
+    // Browsers strip control characters, so "java<TAB>script:" would
+    // survive a naive scheme test; reject such values outright.
+    if( /[\x00-\x1F\x7F]/.test(trimmed) ){ return null; }
+    // Protocol-relative ("//example.com/...") is off-site.
+    if( trimmed.indexOf('//') === 0 ){ return null; }
+    // Site-relative is always acceptable.
+    if( trimmed === '/' || /^\/[^\/]/.test(trimmed) ){ return trimmed; }
+    // Otherwise an explicit, allowed scheme is required.
+    var scheme_match = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.\-]*):/);
+    if( ! scheme_match ){ return null; }
+    var scheme = scheme_match[1].toLowerCase();
+    if( scheme !== 'http' && scheme !== 'https' ){ return null; }
+    return trimmed;
+  }
+
   function _filter_token_from_url(url_str) {
     var ret = url_str;
 
@@ -1987,7 +2011,7 @@ var BaristaLauncher = function () {
     // Get return argument (originating URL) if there.
     var ret = null;
     if (req.query && req.query['return']) {
-      ret = req.query['return'];
+      ret = _safe_return_url(req.query['return']);
       req.session.return = ret;
     }
 
@@ -2013,7 +2037,7 @@ var BaristaLauncher = function () {
     // Get return argument (originating URL) if there.
     var ret = null;
     if (req.query && req.query['return']) {
-      ret = req.query['return'];
+      ret = _safe_return_url(req.query['return']);
     }
     // Get the token, which really should be there.
     var tok = null;
@@ -2069,7 +2093,7 @@ var BaristaLauncher = function () {
     // First, see if we stashed it in the url.
     var ret = null;
     if (req.query && req.query['return']) {
-      ret = req.query['return'];
+      ret = _safe_return_url(req.query['return']);
       console.log('Recovered return URL from URL.');
     }
     // Next, see if we stashed it in the session.
@@ -2120,7 +2144,7 @@ var BaristaLauncher = function () {
     // Get return argument (originating URL) if there.
     var ret = null;
     if (req.query && req.query['return']) {
-      ret = req.query['return'];
+      ret = _safe_return_url(req.query['return']);
     }
     // Get the token, which reall should be there.
     var tok = null;
@@ -2169,7 +2193,7 @@ var BaristaLauncher = function () {
     // Get return argument (originating URL) if there.
     var ret = null;
     if (req.query && req.query['return']) {
-      ret = req.query['return'];
+      ret = _safe_return_url(req.query['return']);
     }
     console.log('/auth/local GET got "return": ' + ret);
     // TODO: Err if nothing to return to?


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Constrains the `return` query parameter before it is used as a link target in barista's login / logout / failure / success pages.

**Problem.** `return` is attacker-controllable and was passed through to the templates unchecked, where it is rendered into an `href`. The templates HTML-escape it (Mustache `{{ }}`), which stops quote-breakout — but escaping does **not** constrain a URL *scheme*, so a non-http(s) scheme survives intact and becomes a clickable link in barista's own origin. Barista brokers sessions and tokens, so that origin matters. The same parameter also accepted arbitrary off-site absolute URLs.

Found by our cloud-security tooling's endpoint prober and reproduced by hand against a development instance; the same code path exists on all deployed branches.

**Fix.** A single helper, `_safe_return_url()`, added beside the existing `_filter_token_from_url()`, applied at all five points where `return` is read from the query string. It accepts site-relative paths and absolute `http`/`https` URLs, and rejects everything else — other schemes, protocol-relative `//host`, values containing control characters (browsers strip those, so `"java<TAB>script:"` would otherwise slip past a naive scheme test), and non-strings. Rejected input becomes `null`, and since the templates already gate the link on `{{#return}}`, the page simply renders without a return link. Login itself is unaffected.

Sanitizing at the read sites means every downstream use is covered — `return_link`, `login_link`, `logout_link`, `_build_token_link()`, and (on this branch) the value stored in `req.session.return`.

**Verification.**

- Helper logic exercised against a matrix of 14 hostile inputs (scheme variants including mixed case and leading whitespace, control-character splitting, `data:`, `vbscript:`, `file:`, protocol-relative, empty/non-string) and 6 legitimate ones (absolute http/https, site-relative, `/`, relative-with-query, uppercase scheme): all rejected / all preserved respectively.
- `node --check` passes.
- Not yet exercised against a running instance — a login round-trip on a dev instance is the remaining check before this reaches production.

**Scope note.** This closes the scheme-injection issue. Restricting the *host* of an absolute return URL (which would also close off-site redirection) is deliberately left out: barista serves several origins and a host allowlist needs its own configuration decision.

Companion PRs apply the identical change to the other deployed branches; they are applied per-branch rather than cherry-picked because the surrounding formatting differs.

---
_— Posted by Claude Code agent on behalf of @kltm._
