### PR TITLE
[bot] Harden return URL handling: backslash bypass, nested encoding, null guard (master)

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -1505,21 +1505,25 @@ var BaristaLauncher = function(){
     // (javascript:, data:, vbscript:, protocol-relative //host) returns null,
     // and callers then render no return link.
     function _safe_return_url(url_str){
-	if( ! url_str || typeof url_str !== 'string' ){ return null; }
+	// Reject control characters and DEL *before* trimming (a redirect
+	// target wrapped in stray whitespace is not something to normalize),
+	// and reject backslashes anywhere: HTTP(S) URL parsing treats "\" as a
+	// path/authority separator, so "/\evil.example" would otherwise pass
+	// the site-relative test below and then navigate to evil.example.
+	if( typeof url_str !== 'string' ||
+	    /[\x00-\x1F\x7F\\]/.test(url_str) ){ return null; }
+
 	var trimmed = url_str.trim();
-	// Browsers strip control characters, so "java<TAB>script:" would
-	// survive a naive scheme test; reject such values outright.
-	if( /[\x00-\x1F\x7F]/.test(trimmed) ){ return null; }
-	// Protocol-relative ("//example.com/...") is off-site.
-	if( trimmed.indexOf('//') === 0 ){ return null; }
-	// Site-relative is always acceptable.
-	if( trimmed === '/' || /^\/[^\/]/.test(trimmed) ){ return trimmed; }
-	// Otherwise an explicit, allowed scheme is required.
-	var scheme_match = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.\-]*):/);
-	if( ! scheme_match ){ return null; }
-	var scheme = scheme_match[1].toLowerCase();
-	if( scheme !== 'http' && scheme !== 'https' ){ return null; }
-	return trimmed;
+
+	// Site-relative (but not protocol-relative "//host"), or a well-formed
+	// absolute http(s) URL with an authority. Everything else -- other
+	// schemes (javascript:, data:, blob:, vbscript:), bare "https:host",
+	// and empty input -- is rejected.
+	if( /^\/(?!\/)/.test(trimmed) ||
+	    /^https?:\/\/[^\/?#]+(?:[\/?#]|$)/i.test(trimmed) ){
+	    return trimmed;
+	}
+	return null;
     }
 
     function _filter_token_from_url(url_str){
@@ -1575,7 +1579,7 @@ var BaristaLauncher = function(){
 	var base_url = '/login/success?barista_token=' +
 		encodeURIComponent(user_token);
 	if( ret_url ){
-	    base_url += '&return=' + ret_url;
+	    base_url += '&return=' + encodeURIComponent(ret_url);
 	}
 	return res.redirect(base_url);
     }
@@ -1585,6 +1589,10 @@ var BaristaLauncher = function(){
     // and noctua.js.
     function _build_token_link(url, token, token_name){
 	var new_url = url;
+
+	// A rejected return URL arrives here as null; without this guard the
+	// token branch below would throw on null.indexOf().
+	if( typeof new_url !== 'string' ){ return new_url; }
 
 	// Default to "barista_token".
 	if( ! token_name ){ token_name = 'barista_token'; }
@@ -2049,8 +2057,9 @@ var BaristaLauncher = function(){
 
 	// We'll need this URL in some cases.
 	var return_link = _build_token_link(ret, tok);
-	var logout_link = _build_token_link('/logout?return='+ ret, tok);
-	var login_link = _build_token_link('/login?return='+ ret, tok);
+	var ret_query = ret ? '?return=' + encodeURIComponent(ret) : '';
+	var logout_link = _build_token_link('/logout' + ret_query, tok);
+	var login_link = _build_token_link('/login' + ret_query, tok);
 
 	var sess = sessioner.get_session_by_token(tok);
 	var user_name = '???';
@@ -2122,7 +2131,7 @@ var BaristaLauncher = function(){
 
 	// We'll need this URL in some cases.
 	var return_link = ret;
-	var login_link = '/login?return='+ ret;
+	var login_link = '/login' + (ret ? '?return=' + encodeURIComponent(ret) : '');
 
 	// Get return argument (originating URL) if there.
     	var tmpl_args = {
@@ -2162,7 +2171,7 @@ var BaristaLauncher = function(){
 
 	// We'll need this URL in some cases.
 	var return_link = ret;
-	var login_link = '/login?return='+ ret;
+	var login_link = '/login' + (ret ? '?return=' + encodeURIComponent(ret) : '');
 
 	//
 	var deleted_session_p = sessioner.delete_session_by_token(tok);


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Follow-up hardening of the `return` handling merged in #1118 / #1119. That change fixed the reported issue (a non-http(s) scheme reaching an `href`), and this one closes three further problems found in an independent review of it.

**1. Backslash bypass in the site-relative branch.** `"/\evil.example"` — reachable as `?return=/%5Cevil.example` — passed the old site-relative test because the second character is not a slash. Browsers treat `\` as a path/authority separator when parsing http(s) URLs, so it resolves off-origin:

```
new URL("/\\evil.example", "https://<host>/logout")  ->  https://evil.example/
```

Not script execution — the scheme check still blocks `javascript:` and friends — but it defeats the same-origin guarantee that branch is supposed to provide. Backslashes are now rejected anywhere in the value.

**2. Unencoded nested query values.** `'/logout?return=' + ret` concatenated the value raw, so `&`, `#`, `%` and `+` in an otherwise-legitimate return could truncate or inject into the outer query — and a value like `/%5Cevil.example` could survive a hop, decode back to a literal backslash, and re-enter problem 1. All four concatenation sites now use `encodeURIComponent()`, and the parameter is omitted entirely when there is no return value (previously these produced a literal `?return=null`).

**3. Crash on a rejected return.** `_build_token_link()` does `url.indexOf('?')`, and a rejected return is `null`, so `/login/success?return=<rejected>&barista_token=<t>` raised `TypeError: Cannot read properties of null`. A non-string guard now returns the input unchanged. (This was reachable before the original fix too, via a request carrying a token and no return, but the earlier change made it much easier to hit.)

Also tightened: control characters and DEL are now checked *before* `trim()`, so a redirect target wrapped in stray tabs/newlines is rejected rather than silently normalized, and the absolute-URL branch requires a well-formed authority, so `https:host` (no `//`) no longer passes.

**Verification.** The two functions were extracted from the patched file and exercised directly: 17 hostile inputs rejected (all previous cases plus the backslash forms), 8 legitimate forms preserved (absolute http/https, site-relative, `/`, query+fragment, uppercase scheme, authority-only), the null case confirmed non-throwing, and link construction checked to encode the nested value and omit the parameter cleanly. `node --check` passes. The construction is ES5 with negative lookahead only — no lookbehind — so it remains valid on both the Node 8 production hosts and the Node 22 branch.

**Still deliberately out of scope:** restricting the *host* of an absolute return URL. That would also close off-site redirection, but barista serves several origins and an allowlist needs its own configuration decision.

One operational note: sessions created before this deploys are not retroactively validated, so either re-check at the sink or accept that a barista restart clears them.

---
_— Posted by Claude Code agent on behalf of @kltm._
