### PR TITLE
[bot] Restore request sanitization under express 5 (silently disabled by the upgrade)

### DIFF
--- a/noctua.js
+++ b/noctua.js
@@ -531,11 +531,33 @@ var NoctuaLauncher = function () {
       'barista_token'];
     if (req && req.query) {
 
+      // Sanitize a copy and install it as an OWN property, rather than
+      // assigning into req.query in place. Express 5 exposes req.query as a
+      // lazy accessor on the prototype that re-parses the query string on
+      // every read, so `req.query[p] = ...` writes into a throwaway object
+      // and every later read still returns the raw value -- which silently
+      // disabled this sanitizer for all of `purgable`. (Express 4 had a
+      // writable own property, so in-place assignment worked there.) An own
+      // property shadows the accessor and is correct on both versions.
+      // Do not "simplify" this back to direct assignment.
+      var raw = req.query;
+      var cleaned = {};
+      Object.keys(raw).forEach(function (k) {
+        cleaned[k] = raw[k];
+      });
+
       each(purgable, function (p) {
-        if (req.query[p]) {
-          req.query[p] = _sanitize(req.query[p]);
+        if (cleaned[p]) {
+          cleaned[p] = _sanitize(cleaned[p]);
           ret = true;
         }
+      });
+
+      Object.defineProperty(req, 'query', {
+        value: cleaned,
+        writable: true,
+        configurable: true,
+        enumerable: true
       });
     }
     return ret;


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Restores request sanitization on this branch. Our cloud-security tooling's endpoint prober flagged XSS via the `barista_token` query parameter on the workbench route, and it reproduces on the development stack.

**The symptom.** The value is reflected into a JS string inside a `<script>` block. The quote is escaped, so JS-string breakout is blocked — but a `</script>` in the value closes the element at the HTML-parser level and whatever follows becomes live markup.

**The cause is not the sanitizer's logic — it is how the sanitizer applies.** `sanitize_request()` works by assigning back into `req.query`. Under **express 5**, `req.query` is a lazy accessor on the prototype that re-parses the query string on each read, so that assignment lands in a throwaway object and every later read (`get_token()`, the template variables) still sees the original value. Under **express 4** it was a writable own property, so the same code worked. It fails **silently**: `sanitize_request()` still returns `true`.

Consequence: every parameter in `purgable` — `model_id`, `individual_id`, `subject_individual_id`, `object_individual_id`, `relation_id`, `barista_token` — has been unsanitized on this branch, on every route that calls it. The prober found one of the six.

**The fix.** Sanitize a copy and install it as an own property, shadowing the accessor. Correct on both express 4 and 5, so it stays correct if this branch is promoted or the change is backported. The comment says plainly not to simplify it back to direct assignment, since that is what regressed.

**Verification.** The function was extracted from the patched file and driven through an express app inside a container running the real express 5.2.1 — testing the shipped code rather than a copy:

| | `barista_token` after sanitize | `model_id` | non-purgable param |
|---|---|---|---|
| this branch today | raw payload returned | raw | preserved |
| with this patch | sanitized | sanitized | preserved |

Both runs report `sanitize_request → true`, which is the point about silence. Values are stable across repeated reads, and a parameter outside `purgable` is passed through untouched. `node --check` passes.

**Not affected:** `master` and `dev` pin express 4.14.0, and production strips these characters as expected — this is specific to the express 5 upgrade on this branch.

**Known remaining gap, unchanged by this PR:** `sanitize_request` only covers `req.query`, never `req.params`. The one route reading a path parameter into page variables (`/basic/:model_type/:query`) returns 404 in both deployments, so nothing exploitable was demonstrated; flagging it rather than widening this change. Separately, character-stripping is a blunt instrument for a generated token — a strict allowlist at `get_token()` would be better hardening, and is deliberately left out of this fix.

---
_— Posted by Claude Code agent on behalf of @kltm._
