### PR TITLE
[bot] Bump pup-tent to 0.9.12 (inline-script rendering hardening)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "passport-google-oauth": "1.0.0",
         "passport-local": "1.0.0",
         "passport-oauth2": "1.8.0",
-        "pup-tent": "0.9.11",
+        "pup-tent": "0.9.12",
         "selectize": "^0.12.1",
         "socket.io": "4.8.3",
         "toastr": "2.1.2",
@@ -3008,9 +3008,9 @@
       }
     },
     "node_modules/pup-tent": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/pup-tent/-/pup-tent-0.9.11.tgz",
-      "integrity": "sha512-xgT7NbQroe4CZe8vlyfq9xXyoivi9WYdhSmZ6oNXWXgcLn7p6DbpRiQWfR2muE9q+h46/WmeLbqMAfVAXE9GOQ==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/pup-tent/-/pup-tent-0.9.12.tgz",
+      "integrity": "sha512-YlWDHseL0+3JchzhuQjLteZB6ArprTM2ZZA4j8jNz1Ir7IZS8PUXBd6N3HgB9fOh3z/aML/N0PaDYhkNiA0ABA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "mustache": "~0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "passport-google-oauth": "1.0.0",
         "passport-local": "1.0.0",
         "passport-oauth2": "1.8.0",
-        "pup-tent": "0.9.10",
+        "pup-tent": "0.9.11",
         "selectize": "^0.12.1",
         "socket.io": "4.8.3",
         "toastr": "2.1.2",
@@ -3008,9 +3008,10 @@
       }
     },
     "node_modules/pup-tent": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/pup-tent/-/pup-tent-0.9.10.tgz",
-      "integrity": "sha1-jPy4AQ+jl5bSruP1Ub4+7prgNlM=",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/pup-tent/-/pup-tent-0.9.11.tgz",
+      "integrity": "sha512-xgT7NbQroe4CZe8vlyfq9xXyoivi9WYdhSmZ6oNXWXgcLn7p6DbpRiQWfR2muE9q+h46/WmeLbqMAfVAXE9GOQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "mustache": "~0.8.2",
         "underscore": "~1.6.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "passport-google-oauth": "1.0.0",
     "passport-local": "1.0.0",
     "passport-oauth2": "1.8.0",
-    "pup-tent": "0.9.10",
+    "pup-tent": "0.9.11",
     "selectize": "^0.12.1",
     "socket.io": "4.8.3",
     "toastr": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "passport-google-oauth": "1.0.0",
     "passport-local": "1.0.0",
     "passport-oauth2": "1.8.0",
-    "pup-tent": "0.9.11",
+    "pup-tent": "0.9.12",
     "selectize": "^0.12.1",
     "socket.io": "4.8.3",
     "toastr": "2.1.2",


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Picks up the fix for the XSS our endpoint prober validated on the development stack.

The value reached the page as a template variable, and pup-tent rendered it into an inline `<script>` with a bare `JSON.stringify` — which escapes quotes and backslashes but not `<`, so a value containing a closing script tag ended the element and the remainder was parsed as markup. **0.9.11** escapes `<` (and `U+2028`/`U+2029`) at that point. It is an encoding change, not a filter: rendered values are unchanged, nothing is stripped.

Fixing the sink covers every template variable rather than the handful any input filter happens to list.

Lockfile regenerated with `--legacy-peer-deps`, matching how the image build resolves this tree. The exact pin is kept rather than the caret npm defaults to.

Upstream: kltm/pup-tent#20 (merged, published).

After merge: rebuild the noctua image and redeploy the bench, then the finding should clear on the next scan.

---
_— Posted by Claude Code agent on behalf of @kltm._