### PR TITLE
[bot] [security] Stop the /doc error page describing the server, and escape the name

### DIFF
--- a/noctua.js
+++ b/noctua.js
@@ -920,21 +920,30 @@ var NoctuaLauncher = function(){
 		var mapped_fname = './context/' + noctua_context +
 			'/markdown-docs/' + fname + '.md';
 
+		// The name is echoed back on failure, and content_insert is
+		// rendered unescaped (it normally carries rendered markdown),
+		// so escape it the same way mustache escapes it in the title
+		// and header.
+		var safe_fname = mustache.escape(fname);
+
+		// One message for every failure. The resolved path, the
+		// context name, and which kind of failure occurred all
+		// describe the server rather than the request, so none of
+		// them are reported to the caller.
+		var not_found = '<h5>no document "' + safe_fname + '"</h5>';
+
 		// Detect if file exists.
 		try {
 		    var fstats = fs.statSync(mapped_fname);
 		    if( ! fstats.isFile() ){
-			// Catch error here if not found.
-			final_content = '<h5>' + fname + '" not file</h5>';
+			final_content = not_found;
 		    }else{
 			// Grab markdown renderable file.
 			var fname_raw = fs.readFileSync(mapped_fname).toString();
 			final_content = md.markdown.toHTML(fname_raw);
 		    }
 		} catch(e) {
-		    // Catch error here if not found.
-		    final_content = '<h5>no "' + fname + '" for "' +
-			noctua_context + '"</h5>: ' + mapped_fname;
+		    final_content = not_found;
 		}
 	    }
 


### PR DESCRIPTION
Opened by a Claude Code agent on behalf of @kltm. Routine proactive security maintenance.

## What was wrong

`/doc/:fname` builds its failure content by concatenating the requested name into HTML, and that content is rendered through `content_insert`, which `noctua_markdoc.tmpl` emits unescaped because the success path legitimately puts rendered markdown there. So a name containing markup reached the page as markup.

The same name is correctly escaped in the page title and the panel header, which is what made this easy to miss — the page looks encoded until you compare the two regions.

The failure text also described the server rather than the request: it appended the resolved filesystem path, named the deployment context, and distinguished "not a file" from "not found". Together those disclose the layout under the context directory and answer questions about what exists there.

## The change

* Escape the name with `mustache.escape`. Already a dependency and already required in this file, and deliberately chosen over a hand-rolled escaper: it is the exact function mustache applies to `{{ }}`, so the failure text now encodes the name the same way the title and header on the same page already do.
* Replace all three failure texts with one message that reports only the name the caller asked for.

`{{&content_insert}}` is deliberately left unescaped — the success path depends on it — so the fix belongs at construction rather than at the template.

## Verification

Exercised against a running server rather than reasoned about:

| case | result |
| --- | --- |
| markup in the name | returned as text, not markup |
| attribute-breakout attempt | encoded |
| name resolving to a directory | now indistinguishable from a name that does not exist |
| ordinary name | still echoed unchanged |
| real document | still renders as markdown |

No filesystem path or context name appears in any response.

An earlier revision of this change logged the resolved path instead of returning it. That was dropped: the name reaches the log unmodified, and a name containing CR/LF splits one log line into two. The request URL is already logged upstream, so the line added nothing.

## Scope

One route. The unescaped `content_insert` slot, the markdown rendering path, and a broader review of other routes are all deliberately untouched here.

_— Posted by Claude Code agent on behalf of @kltm._