### PR TITLE
[bot] [security] Stop the /doc error page describing the server, and escape the name (node-LTS)

### DIFF
--- a/noctua.js
+++ b/noctua.js
@@ -14,6 +14,7 @@
 
 // Required shareable Node libs.
 var md = require('markdown');
+var mustache = require('mustache');
 var fs = require('node:fs');
 var path = require('node:path');
 var tilde = require('expand-home-dir');
@@ -993,21 +994,30 @@ var NoctuaLauncher = function () {
         var mapped_fname = './context/' + noctua_context +
           '/markdown-docs/' + fname + '.md';
 
+        // The name is echoed back on failure, and content_insert is
+        // rendered unescaped (it normally carries rendered markdown),
+        // so escape it the same way mustache escapes it in the title
+        // and header.
+        var safe_fname = mustache.escape(fname);
+
+        // One message for every failure. The resolved path, the context
+        // name, and which kind of failure occurred all describe the
+        // server rather than the request, so none of them are reported
+        // to the caller.
+        var not_found = '<h5>no document "' + safe_fname + '"</h5>';
+
         // Detect if file exists.
         try {
           var fstats = fs.statSync(mapped_fname);
           if (!fstats.isFile()) {
-            // Catch error here if not found.
-            final_content = '<h5>' + fname + '" not file</h5>';
+            final_content = not_found;
           } else {
             // Grab markdown renderable file.
             var fname_raw = fs.readFileSync(mapped_fname).toString();
             final_content = md.markdown.toHTML(fname_raw);
           }
         } catch (e) {
-          // Catch error here if not found.
-          final_content = '<h5>no "' + fname + '" for "' +
-            noctua_context + '"</h5>: ' + mapped_fname;
+          final_content = not_found;
         }
       }
 


### PR DESCRIPTION
Opened by a Claude Code agent on behalf of @kltm. Routine proactive security maintenance.

Companion to #1125, which makes the same change on `master`. This branch carries the same defect, so it needs its own fix rather than inheriting one.

## What was wrong

`/doc/:fname` builds its failure content by concatenating the requested name into HTML, and that content is rendered through `content_insert`, which the template emits unescaped because the success path legitimately puts rendered markdown there. So a name containing markup reached the page as markup — while the same name is correctly escaped in the title and panel header, which is what made it easy to miss.

The failure text also described the server rather than the request: the resolved filesystem path, the deployment context name, and a "not a file" versus "not found" distinction.

## The change

Same as #1125 — escape the name with `mustache.escape`, and collapse the three failure texts into one that reports only the name the caller asked for — applied in this branch's formatting.

**One line this branch needs that `master` does not:** `mustache` is listed in `package.json` here but is not required in `noctua.js`, so calling its escape helper without adding the require would have thrown on every miss — turning the reported problem into a crash. The require is added.

That difference is the reason this is a separate commit rather than a cherry-pick, and worth a moment of review attention.

## Verification

Syntax-checked, and the equivalent change on `master` was exercised against a running server (markup returned as text, attribute-breakout encoded, no path or context in any response, a directory name indistinguishable from a missing one, ordinary names still echoed, real documents still rendering).

**A full runtime check was not possible for this branch locally.** Its dependency set differs from `master`'s — this branch expects a newer `mime` API — so the server exits in an unrelated static-file route when run against the other branch's installed modules. The added require is therefore verified by inspection and syntax check rather than by execution, which is the one thing worth confirming before merge.

## Scope

One route. The unescaped `content_insert` slot, the markdown rendering path, and other routes are deliberately untouched.

_— Posted by Claude Code agent on behalf of @kltm._
