### PR TITLE
[bot] [security] Escape the error page, and stop trusting two third-party values

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -2120,7 +2120,8 @@ var BaristaLauncher = function () {
       // Fall back on trying to get return argument from the header
       // referer.
       if (!ret) {
-        ret = _extract_referer_query_field(req, 'return');
+        // Referer-sourced and lands in an href; validate as the query tier does.
+        ret = _safe_return_url(_extract_referer_query_field(req, 'return'));
         if (ret) {
           console.log('Recovered return URL from field.');
         } else {

--- a/js/lib/noctua-widgetry/widgetry.js
+++ b/js/lib/noctua-widgetry/widgetry.js
@@ -2493,7 +2493,8 @@ function edit_annotations_modal(annotation_config, ecore, manager, entity_id,
                 resp.raw()['results']['bindings'][0] &&
                 resp.raw()['results']['bindings'][0]['title']) {
                 var tt = resp.raw()['results']['bindings'][0]['title']['value'];
-                jQuery("#" + app_elt_uuid).html(tt);
+                // Third-party editable; .text() renders, does not parse.
+                jQuery("#" + app_elt_uuid).text(tt);
               } else {
                 console.log('wikidata return structure bad');
               }

--- a/noctua.js
+++ b/noctua.js
@@ -560,7 +560,8 @@ var NoctuaLauncher = function () {
 
   self.standard_response = function (res, code, type, body) {
     res.setHeader('Content-Type', type);
-    res.setHeader('Content-Length', body.length);
+    // Bytes, not characters: barista hit this and fixed it the same way.
+    res.setHeader('Content-Length', Buffer.byteLength(body, 'utf-8'));
     res.end(body);
     return res;
   };
@@ -1107,8 +1108,9 @@ var NoctuaLauncher = function () {
 
       //console.log(req.route);
       //console.log(req.params['query']);
-      var etype = self.get_qp(req, 'type') || 'unclassified error';
-      var emessage = self.get_qp(req, 'message') || 'unknown error';
+      // sanitize_request does not reach these: it walks a fixed key list.
+      var etype = mustache.escape(self.get_qp(req, 'type') || 'unclassified error');
+      var emessage = mustache.escape(self.get_qp(req, 'message') || 'unknown error');
 
       var fin = [
         '<html>',


### PR DESCRIPTION
Opened by a Claude Code agent on behalf of @kltm. Routine proactive security maintenance, not a response to a reported incident.

Part of a review across our public-facing repositories, tracked in geneontology/operations#104. Targets this branch rather than `master` because this is the line that becomes production.

## The common thread

None of these three are covered by `sanitize_request`. That function is called at the top of most handlers and reads like protection, but it walks `req.query` only, and only six fixed keys — so a seventh query key, anything in the path, any header, and anything arriving from a third-party API all pass through untouched. Every sink below is one of those four categories.

## What changed

**`/error`** built its page by concatenating the `type` and `message` query parameters straight into `text/html`. Neither key is in that list. Both are escaped now, with the same helper the `/doc` route uses, so the two error paths agree.

**The evidence pane** rendered a citation title fetched from Wikidata through `.html()`, which parses its argument as markup. Wikidata is openly editable, and the lookup fires automatically for any PMID cited by a model. It uses `.text()` now — the pane wants to display the title, not interpret it. A title carrying markup will now show it literally, which is the right reading of a value we do not own.

**Barista** resolved a return URL from three sources and validated two. The third reads the field out of the `Referer` header and went straight into an `href`, where escaping would not have helped anyway: a `javascript:` URL contains no metacharacters to escape. It now goes through the same `_safe_return_url` the query-parameter tier already used. That validator fails closed, and the token filter it feeds is guarded, so an unusable `Referer` yields no return link rather than an error.

## One extra line, because the fix already exists next door

`standard_response` set `Content-Length` from the JavaScript string length, which counts characters rather than bytes — so any response carrying a non-ASCII character was declared short. `barista.js` hit this and fixed it with `Buffer.byteLength`, complete with a `NOTE: we got bitten` comment; `noctua.js` was missed.

It is included here because it is one line, has an exact precedent in the sibling file, and sits in the function serving the route this PR already touches. It is also the likely reason an automated probe using a non-ASCII payload would see a truncated error page and read it as a miss.

## Verification

Run against a live server, not read off the diff: markup in either `/error` parameter comes back as text, an attribute-breakout attempt is inert, ordinary messages and the no-parameter defaults still read normally, and `Content-Length` now matches the body exactly for euro, CJK and mixed escaped-payload-plus-multibyte cases.

An adversarial review pass raised two conditions on the barista change — that the validator fails closed, and that the filter downstream tolerates a missing value. Both were checked in the source rather than assumed; neither introduces an error path.

## Deliberately not included

* A charset declaration on these responses. The gap it closes is a legacy-browser one, and `standard_response` serves every response type, so it is a wider change than this should carry.
* `rel="noopener noreferrer"` on outbound links — cheap, but unrelated to injection.
* `login.js` carries several sinks of this kind, but is already absent from this branch and referenced by nothing.

_— Posted by Claude Code agent on behalf of @kltm._
