### PR TITLE
[bot] [security] Escape GitHub issue titles before building link markup from them

### DIFF
--- a/js/NoctuaEditor.js
+++ b/js/NoctuaEditor.js
@@ -40,6 +40,7 @@ var jsPlumb = require('jsplumb');
 //require('bootstrap');
 //require('tablesorter');
 //require('./js/connectors-sugiyama.js');
+var us = require('underscore');
 var bbop_legacy = require('bbop').bbop;
 var bbopx = require('bbopx');
 var amigo_inst_gen = require('amigo2-instance-data');
@@ -3006,7 +3007,9 @@ jsPlumb.ready(function () {
               var url = item['html_url'];
               var number = item['number'];
               if (title && title.indexOf(global_id) !== -1) {
-                var menu_link = '<li><a href="' + url + '" title="' + title + '" target="_blank"><strong style="color:green;">Open</strong> ' + title + ' (#' + number + ')</a></li>';
+                // Issue titles are writable by anyone with a GitHub account.
+                var safe_title = us.escape(title);
+                var menu_link = '<li><a href="' + url + '" title="' + safe_title + '" target="_blank"><strong style="color:green;">Open</strong> ' + safe_title + ' (#' + number + ')</a></li>';
                 to_append += menu_link;
               }
             });

--- a/js/NoctuaLanding.js
+++ b/js/NoctuaLanding.js
@@ -377,8 +377,10 @@ var MinervaBootstrapping = function (user_token, issue_list) {
           var number = issue['number'];
           var url = issue['url'];
           if (title && title.indexOf(model_id) !== -1) {
+            // Issue titles are writable by anyone with a GitHub account.
+            var safe_title = us.escape(title);
             var link = '<a href="' + url +
-              '" title="' + title + '"' +
+              '" title="' + safe_title + '"' +
               ' target="_blank">#' + number +
               '</a>';
             retlist.push(link);


### PR DESCRIPTION
Opened by a Claude Code agent on behalf of @kltm. Routine proactive security maintenance, not a response to a reported incident.

Part of a review across our public-facing repositories, tracked in geneontology/operations#104. Companion to the reflected-sink PR on the same branch, kept separate because this one is a different trust question and deserves its own read.

## The situation

The editor and the landing page both ask the GitHub API for issues mentioning a model, and build their links by concatenating the issue **title** into HTML — into a `title` attribute in both places, and into the link text as well in the editor.

`noctua-models` is a public repository with issues open, so an issue title is writable by **anyone with a GitHub account**. The pages that render it are pages a logged-in curator has open, and this application keeps the session token in a page global. The only gate was a check that the title mentions the model id — which whoever writes the title also controls.

Worth stating plainly because it differs from the usual reflected case: nobody has to click a crafted link. The payload sits in a public issue tracker and fires when a curator opens the affected model.

## What changed

The title is escaped with underscore's `escape`, which the landing page already imports; the editor gains the same import.

The link URL is deliberately left as it is. It is the API's own `html_url` / `url` field, which GitHub generates rather than the issue author, so it is not attacker-settable in the way the title is.

## Verification

Both concatenations were run with a title carrying a quote and a tag: the markup is inert in each position, and an ordinary title is unchanged.

An adversarial review pass confirmed that underscore's escape is sufficient for both a double-quoted attribute and element text here — backtick and `=` are not special inside a quoted attribute — and that adding the import to a browserify entry point is safe, since the module is deduplicated within a bundle.

## Why this is not the same call as the index question

A sibling finding in the ontology browser was set aside on the grounds that the browser is a read-only consumer and responsibility sits with whoever writes the index. That reasoning does not transfer here: there is no gatekeeper on a public issue tracker or on an openly editable third-party knowledge base, so the boundary has to be at our render.

_— Posted by Claude Code agent on behalf of @kltm._
